### PR TITLE
Added [MetaJSON] to dist.ini so releases will include a META.json

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -7,6 +7,7 @@ copyright_year   = 2013
 [@Basic]
 
 [AutoPrereqs]
+[MetaJSON]
 
 [AutoVersion]
 


### PR DESCRIPTION
Hi Dana,

This is a small change which adds [MetaJSON] to dist.ini, so that releases will include a META.json file.

The META.json file has better fidelity of dependency information that META.yml.

Cheers,
Neil
